### PR TITLE
Fix #32: Header should not streatch to extreme sides

### DIFF
--- a/src/components/section-components/Header/style.header.css
+++ b/src/components/section-components/Header/style.header.css
@@ -8,7 +8,9 @@ header.header {
   -webkit-box-pack: justify;
       -ms-flex-pack: justify;
           justify-content: space-between;
-  margin-top: 3.4em;
+  margin: auto;
+  margin-top: 2em;
+  width: 90%;
 }
 
 header.header > a.logo-wrapper-link > div.logo-wrapper {


### PR DESCRIPTION
Add margin to header left and right 
decreased header top margin

![image](https://user-images.githubusercontent.com/41536903/135531649-f4ad96b6-1722-4b65-96de-75ca80568580.png)
